### PR TITLE
skipTypeImports option

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,10 @@ var Walker = require('node-source-walk');
  * Extracts the dependencies of the supplied es6 module
  *
  * @param  {String|Object} src - File's content or AST
+ * @param  {Object} options - optional extra settings
  * @return {String[]}
  */
-module.exports = function(src) {
+module.exports = function(src, options) {
   const walker = new Walker();
 
   const dependencies = [];
@@ -22,6 +23,9 @@ module.exports = function(src) {
   walker.walk(src, function(node) {
     switch (node.type) {
       case 'ImportDeclaration':
+        if (options && options.skipTypeImports && node.importKind == 'type') {
+          break;
+        }
         if (node.source && node.source.value) {
           dependencies.push(node.source.value);
         }

--- a/test/test.js
+++ b/test/test.js
@@ -96,4 +96,12 @@ describe('detective-es6', function() {
       detective('import foo from \'foo\'; export default async function foo() {}');
     });
   });
+
+  it('respects settings for type imports', function() {
+    const source = 'import type {foo} from "mylib";';
+    const depsWithTypes = detective(source);
+    const depsWithoutTypes = detective(source, {skipTypeImports: true});
+    assert.deepEqual(depsWithTypes, ['mylib']);
+    assert.deepEqual(depsWithoutTypes, []);
+  });
 });


### PR DESCRIPTION
## Why
* my team is using the `madge` tool to reject circular deps in CI, which depends on detective-es6 via `dependency-tree` and `precinct`
* we want to permit cycles with `import type` -- it's convenient and has no impact on runtime behavior
* someone raised this last year in this madge issue: https://github.com/pahen/madge/issues/174
## What
* this adds a `skipTypeImports` option to the walk behavior
* madge can pass this down via `.madgerc` like:
```json
  "detectiveOptions": {
    "es6": { "skipTypeImports": true }
  }
```