### PR TITLE
Allow skip async imports

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,8 +15,13 @@ var mySourceCode = fs.readFileSync('myfile.js', 'utf8');
 var dependencies = detective(mySourceCode);
 
 ```
-
 * Supports JSX, Flow, and any other features that [node-source-walk](https://github.com/mrjoelkemp/node-source-walk) supports.
+
+You may also (optionally) configure the detective via a second object argument detective(src, options) that supports the following options:
+
+- skipTypeImports: (Boolean) whether or not to omit type imports (`import type {foo} from "mylib";`) in the list of extracted dependencies.
+- skipAsyncImports: (Boolean) whether or not to omit async imports (`import('foo')`) in the list of extracted dependencies.
+
 
 #### License
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,9 @@ module.exports = function(src, options) {
         }
         break;
       case 'CallExpression':
+        if (options && options.skipAsyncImports) {
+          break;
+        }
         if (node.callee.type === 'Import' && node.arguments.length) {
           dependencies.push(node.arguments[0].value);
         }

--- a/test/test.js
+++ b/test/test.js
@@ -104,4 +104,12 @@ describe('detective-es6', function() {
     assert.deepEqual(depsWithTypes, ['mylib']);
     assert.deepEqual(depsWithoutTypes, []);
   });
+
+  it('respects settings for async imports', function() {
+    const source = 'import("myLib")';
+    const depsWithAsync = detective(source);
+    const depsWithoutAsync = detective(source, {skipAsyncImports: true});
+    assert.deepEqual(depsWithAsync, ['myLib']);
+    assert.deepEqual(depsWithoutAsync, []);
+  });
 });


### PR DESCRIPTION
## Motivation

I was experimenting with [Madge](https://www.npmjs.com/package/madge) and found that a really interesting use case would be to analyze the module structure of an individual async bundle. Unfortunately AFAICT there's no way to stop the analysis at the border of async imports `import()`.

## Solution

Looking at [Detective-AMD](https://github.com/dependents/node-detective-amd#usage) I found it had a `skipLazyLoaded` option which is similar to what I was looking for. By adding an `options.skipAsyncImports` or `options.skipLazyImports` etc. we could stop the traversal at the bundle boundaries.

## Next Steps

I was hoping you could take a look at this change and determine whether it makes sense to further pursue, and I can go ahead and write tests etc.

- [ ] confirm direction
- [ ] settle on naming convention
- [x] test skip behavior
- [x] add documentation for new option

Thanks for taking a look!