### PR TITLE
fix async imports with variable parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = function(src, options) {
         if (options && options.skipAsyncImports) {
           break;
         }
-        if (node.callee.type === 'Import' && node.arguments.length) {
+        if (node.callee.type === 'Import' && node.arguments.length && node.arguments[0].value) {
           dependencies.push(node.arguments[0].value);
         }
       default:


### PR DESCRIPTION
- code such as import(computed_variable) would cause an undefined
  to be returned in the dependency array
- now it will be skipped instead
- code with a static string in the import call such as import('file.js')
  already worked and still works